### PR TITLE
Set cm shell encoding to UTF-8 like other plugins

### DIFF
--- a/plastic/operations/command.py
+++ b/plastic/operations/command.py
@@ -49,7 +49,7 @@ def __initialize_plastic_shell():
     global __cm_shell_process
 
     __cm_shell_process = subprocess.Popen(
-        [__cm_command_path, 'shell'],
+        [__cm_command_path, 'shell', '--encoding=UTF-8'],
         stdin = subprocess.PIPE,
         stdout = subprocess.PIPE,
         cwd = __get_command_cwd(),


### PR DESCRIPTION
Without that encoding flags, accents in changeset's comments (log/history) or in error messages wouldn't be parsed correctly by Python (assuming you use utf-8 decode)

Cheers!